### PR TITLE
Implement Exception behaviour for Twirp.Error

### DIFF
--- a/lib/twirp/error.ex
+++ b/lib/twirp/error.ex
@@ -34,7 +34,7 @@ defmodule Twirp.Error do
   @error_code_strings for code <- @error_codes, do: Atom.to_string(code)
 
   @derive Jason.Encoder
-  defstruct ~w|code msg meta|a
+  defexception ~w|code msg meta|a
 
   @type t :: %__MODULE__{
     code: atom(),
@@ -66,4 +66,7 @@ defmodule Twirp.Error do
   def new(code, msg, meta \\ []) do
     conform!(%__MODULE__{code: code, msg: msg, meta: Enum.into(meta, %{})}, s())
   end
+
+  @impl true
+  def message(%__MODULE__{msg: msg}), do: msg
 end

--- a/test/twirp/error_test.exs
+++ b/test/twirp/error_test.exs
@@ -1,0 +1,12 @@
+defmodule Twirp.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Twirp.Error
+
+  describe "message/1 callback" do
+    test "returns the msg value" do
+      error = Error.new(:invalid_argument, "I can't make a hat that small!")
+      assert "I can't make a hat that small!" == Exception.message(error)
+    end
+  end
+end


### PR DESCRIPTION
This is useful when `Twirp.Error` is passed to things like Spandex, which calls `Exception.message/1` on the error struct.