### PR TITLE
Add callbacks for RPC methods to generated services

### DIFF
--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -22,6 +22,10 @@ defmodule <%= mod_name %>Client do
 
   @type ctx :: map()
 
+  <%= Enum.map methods, fn method -> %>
+      @callback <%= method.handler_fn %>(ctx(), <%= method.input %>.t()) :: {:ok, <%= method.output %>.t()} | {:error, Twirp.Error.t()}
+  <% end %>
+
   def child_spec(opts) do
     %{
       id: __MODULE__,


### PR DESCRIPTION
This can be useful when mocking the service with something like Mox.