### PR TITLE
Fix JSON decoding nested fields

### DIFF
--- a/lib/twirp/encoder.ex
+++ b/lib/twirp/encoder.ex
@@ -32,19 +32,19 @@ defmodule Twirp.Encoder do
         {:error, e}
     end
   end
-  def decode(map, input, @json <> _) do
-    map_with_atoms =
-      map
-      |> Enum.map(fn {key, v} ->
-        k = if is_binary(key), do: String.to_existing_atom(key), else: key
-        {k, v}
-      end)
-      |> Enum.into(%{})
 
-    {:ok, input.new(map_with_atoms)}
-  rescue
-    e ->
-      {:error, e}
+  def decode(map, input, @json <> _) do
+    case Jason.encode(map) do
+      {:ok, bytes} ->
+        decode(bytes, input, @json)
+
+      {:error, e} ->
+        {:error, e}
+    end
+
+    rescue
+      e ->
+        {:error, e}
   end
 
   def decode(bytes, input, @proto <> _) do

--- a/test/twirp/encoder_test.exs
+++ b/test/twirp/encoder_test.exs
@@ -9,6 +9,11 @@ defmodule Twirp.EncoderTest do
     test "converts json to protobuf" do
       assert {:ok, %Req{msg: "test"}} = Encoder.decode(%{msg: "test"}, Req, "application/json")
     end
+
+    test "converts nested string fields" do
+      assert {:ok, %Envelope{msg: "test", sub: %Req{msg: "test"}}} ==
+        Encoder.decode(%{"msg" => "test", "sub" => %{"msg" => "test"}}, Envelope, "application/json")
+    end
   end
 
   describe "encode/3 as json " do


### PR DESCRIPTION
Decoding nested fields when the body has been pre-parsed was resulting
in returning the default values for the nested fields, rather than the
values passed in the request.

