### PR TITLE
Strip structs when encoding lists as JSON

### DIFF
--- a/lib/twirp/encoder.ex
+++ b/lib/twirp/encoder.ex
@@ -1,5 +1,6 @@
 defmodule Twirp.Encoder do
   @moduledoc false
+
   # Encodes and Decodes messages based on the requests content-type header.
   # For json we delegate to Jason. for protobuf responses we use the input or
   # output types.
@@ -32,6 +33,7 @@ defmodule Twirp.Encoder do
         {:error, e}
     end
   end
+
   def decode(map, input, @json <> _) do
     struct =
       map
@@ -60,17 +62,21 @@ defmodule Twirp.Encoder do
   def encode(payload, _output, @json <> _) do
     payload
     |> strip_structs()
-    |> Jason.encode!
+    |> Jason.encode!()
   end
 
   def encode(payload, output, @proto <> _) do
     output.encode(payload)
   end
 
+  defp strip_structs(list) when is_list(list) do
+    Enum.map(list, &strip_structs/1)
+  end
+
   defp strip_structs(map) when is_map(map) do
     map
     |> Map.drop([:__struct__])
-    |> Enum.into(%{}, fn {k,v} -> {k, strip_structs(v)} end)
+    |> Enum.into(%{}, fn {k, v} -> {k, strip_structs(v)} end)
   end
 
   defp strip_structs(any), do: any

--- a/test/support/service.pb.ex
+++ b/test/support/service.pb.ex
@@ -35,3 +35,27 @@ defmodule Twirp.Test.Resp do
 
   field :msg, 1, type: :string
 end
+
+defmodule Twirp.Test.BatchReq do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          requests: [Twirp.Test.Req.t()]
+        }
+  defstruct [:requests]
+
+  field :requests, 1, repeated: true, type: Twirp.Test.Req
+end
+
+defmodule Twirp.Test.BatchResp do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          responses: [Twirp.Test.Resp.t()]
+        }
+  defstruct [:responses]
+
+  field :responses, 1, repeated: true, type: Twirp.Test.Resp
+end

--- a/test/support/service.proto
+++ b/test/support/service.proto
@@ -16,9 +16,19 @@ message Resp {
   string msg = 1;
 }
 
+message BatchReq {
+  repeated Req requests = 1;
+}
+
+message BatchResp {
+  repeated Resp responses = 1;
+}
+
 service Echo {
   // Echo's some text back to you
   rpc Echo(Req) returns (Resp);
+
+  rpc BatchEcho(BatchReq) returns (BatchResp);
 
   // Echo's some text back to you, slowly.
   rpc SlowEcho(Req) returns (Resp);

--- a/test/support/service_twirp.ex
+++ b/test/support/service_twirp.ex
@@ -9,6 +9,8 @@ defmodule Twirp.Test.EchoService do
 
   rpc :Echo, Twirp.Test.Req, Twirp.Test.Resp, :echo
 
+  rpc :BatchEcho, Twirp.Test.BatchReq, Twirp.Test.BatchResp, :batch_echo
+
   rpc :SlowEcho, Twirp.Test.Req, Twirp.Test.Resp, :slow_echo
 
   rpc :Undocumented, Twirp.Test.Req, Twirp.Test.Resp, :undocumented
@@ -26,6 +28,9 @@ defmodule Twirp.Test.EchoClient do
 
   @callback echo(ctx(), Twirp.Test.Req.t()) ::
               {:ok, Twirp.Test.Resp.t()} | {:error, Twirp.Error.t()}
+
+  @callback batch_echo(ctx(), Twirp.Test.BatchReq.t()) ::
+              {:ok, Twirp.Test.BatchResp.t()} | {:error, Twirp.Error.t()}
 
   @callback slow_echo(ctx(), Twirp.Test.Req.t()) ::
               {:ok, Twirp.Test.Resp.t()} | {:error, Twirp.Error.t()}
@@ -71,6 +76,12 @@ defmodule Twirp.Test.EchoClient do
   @spec echo(ctx(), Twirp.Test.Req.t()) :: {:ok, Twirp.Test.Resp.t()} | {:error, Twirp.Error.t()}
   def echo(ctx \\ %{}, %Twirp.Test.Req{} = req) do
     rpc(:Echo, ctx, req, Twirp.Test.Req, Twirp.Test.Resp)
+  end
+
+  @spec batch_echo(ctx(), Twirp.Test.BatchReq.t()) ::
+          {:ok, Twirp.Test.BatchResp.t()} | {:error, Twirp.Error.t()}
+  def batch_echo(ctx \\ %{}, %Twirp.Test.BatchReq{} = req) do
+    rpc(:BatchEcho, ctx, req, Twirp.Test.BatchReq, Twirp.Test.BatchResp)
   end
 
   @doc """

--- a/test/twirp/encoder_test.exs
+++ b/test/twirp/encoder_test.exs
@@ -4,6 +4,7 @@ defmodule Twirp.EncoderTest do
   alias Twirp.Encoder
   alias Twirp.Test.Req
   alias Twirp.Test.Envelope
+  alias Twirp.Test.BatchReq
 
   describe "decode/3 with json" do
     test "converts json to protobuf" do
@@ -12,14 +13,45 @@ defmodule Twirp.EncoderTest do
 
     test "converts nested string fields" do
       assert {:ok, %Envelope{msg: "test", sub: %Req{msg: "test"}}} ==
-        Encoder.decode(%{"msg" => "test", "sub" => %{"msg" => "test"}}, Envelope, "application/json")
+               Encoder.decode(
+                 %{"msg" => "test", "sub" => %{"msg" => "test"}},
+                 Envelope,
+                 "application/json"
+               )
+    end
+
+    test "converts nested JSON to nested structs" do
+      assert {:ok, %Envelope{sub: %Req{msg: "test"}}} =
+               Encoder.decode(%{sub: %{msg: "test"}}, Envelope, "application/json")
+    end
+
+    test "converts JSON rith repeated fields to structs" do
+      assert {:ok, %BatchReq{requests: [%Req{msg: "test1"}, %Req{msg: "test2"}]}} =
+               Encoder.decode(
+                 %{requests: [%{msg: "test1"}, %{msg: "test2"}]},
+                 BatchReq,
+                 "application/json"
+               )
     end
   end
 
   describe "encode/3 as json " do
     test "encodes to JSON without implementing a JSON protocol" do
       assert ~S({"msg":"test","sub":{"msg":"test"}}) ==
-        Encoder.encode(%Envelope{msg: "test", sub: %Req{msg: "test"}}, Envelope, "application/json")
+               Encoder.encode(
+                 %Envelope{msg: "test", sub: %Req{msg: "test"}},
+                 Envelope,
+                 "application/json"
+               )
+    end
+
+    test "encodes repeated structs as JSON without implementing a JSON protocol" do
+      assert ~S({"requests":[{"msg":"test1"},{"msg":"test2"}]}) ==
+               Encoder.encode(
+                 %BatchReq{requests: [%Req{msg: "test1"}, %Req{msg: "test2"}]},
+                 BatchReq,
+                 "application/json"
+               )
     end
   end
 end


### PR DESCRIPTION
We were getting errors about missing Jason protocols for encoding
structs nested in lists. This strips the __struct__ field from all
members of lists when encoding as JSON.