### PR TITLE
Handle nested string lists

### DIFF
--- a/lib/twirp/encoder.ex
+++ b/lib/twirp/encoder.ex
@@ -88,5 +88,14 @@ defmodule Twirp.Encoder do
       {k, v}
     end
   end
-  defp to_atom_keys(other), do: other
+
+  defp to_atom_keys(list) when is_list(list) do
+    for item <- list do
+      to_atom_keys(item)
+    end
+  end
+
+  defp to_atom_keys(other) do
+    other
+  end
 end

--- a/test/twirp/encoder_test.exs
+++ b/test/twirp/encoder_test.exs
@@ -33,6 +33,17 @@ defmodule Twirp.EncoderTest do
                  "application/json"
                )
     end
+
+    test "converts string keys to atom keys in nested lists fields" do
+      response =
+        Encoder.decode(
+          %{"requests" => [%{"msg" => "test1"}, %{"msg" => "test2"}]},
+          BatchReq,
+          "application/json"
+        )
+
+      assert {:ok, %BatchReq{requests: [%Req{msg: "test1"}, %Req{msg: "test2"}]}} = response
+    end
   end
 
   describe "encode/3 as json " do


### PR DESCRIPTION
When we send a request that has a list of nested fields, it is not converting the keys from string to atoms correctly.