### PR TITLE
Fix Hackney adapter

### DIFF
--- a/lib/twirp/client/hackney.ex
+++ b/lib/twirp/client/hackney.ex
@@ -28,7 +28,7 @@ defmodule Twirp.Client.Hackney do
 
     with {:ok, status, headers, ref} <- :hackney.request(:post, path, ctx.headers, payload, options),
          {:ok, body} <- :hackney.body(ref) do
-      {:ok, %{status: status, headers: headers, body: body}}
+      {:ok, %{status: status, headers: format_headers(headers), body: body}}
     else
       {:error, :timeout} ->
         {:error, %{reason: :timeout}}
@@ -41,6 +41,12 @@ defmodule Twirp.Client.Hackney do
 
       error ->
         error
+    end
+  end
+
+  defp format_headers(headers) do
+    for {key, value} <- headers do
+      {String.downcase(to_string(key)), to_string(value)}
     end
   end
 end

--- a/lib/twirp/plug.ex
+++ b/lib/twirp/plug.ex
@@ -81,8 +81,7 @@ defmodule Twirp.Plug do
 
   def call(%{path_info: [full_name, method]}=conn, {%{full_name: full_name}=service, handler, hooks}) do
     env = %{}
-    metadata = %{
-    }
+    metadata = %{}
     start = Telemetry.start(:call, metadata)
 
     try do


### PR DESCRIPTION
Because header keys are case-insensitive in both HTTP/1.1 and HTTP/2, it is recommended for header keys to be in lowercase, to avoid sending duplicate keys in a request.