### PR TITLE
Set response header content-type charset to nil

### DIFF
--- a/lib/twirp/plug.ex
+++ b/lib/twirp/plug.ex
@@ -105,7 +105,7 @@ defmodule Twirp.Plug do
         Telemetry.stop(:call, start, metadata)
 
         conn
-        |> put_resp_content_type(env.content_type)
+        |> put_resp_content_type(env.content_type, nil)
         |> send_resp(200, resp)
         |> halt()
       else
@@ -283,7 +283,7 @@ defmodule Twirp.Plug do
     body = Encoder.encode(error, nil, content_type)
 
     conn
-    |> put_resp_content_type(content_type)
+    |> put_resp_content_type(content_type, nil)
     |> send_resp(Error.code_to_status(error.code), body)
     |> halt()
   end

--- a/test/twirp/plug_test.exs
+++ b/test/twirp/plug_test.exs
@@ -73,10 +73,9 @@ defmodule Twirp.PlugTest do
   end
 
   def content_type(conn) do
-    conn.resp_headers
-    |> Enum.find_value(fn {h, v} -> if h == "content-type", do: v, else: false end)
-    |> String.split(";") # drop the charset if there is one
-    |> Enum.at(0)
+   Enum.find_value(conn.resp_headers, fn {h, v} ->
+      if h == "content-type", do: v, else: false
+    end)
   end
 
   def call(req, opts \\ @opts) do


### PR DESCRIPTION
The twirp ruby client explicitly expects the content-type to be either `"application/json"` or `"application/protobuf"`.

https://github.com/twitchtv/twirp-ruby/blob/main/lib/twirp/encoding.rb#L19-L24

This leads to following error:

```ruby
=> #<Twirp::ClientResp:0x00007fdf03c1eed8 
  @data=nil, 
  @error= <Twirp::Error 
    code:internal 
    msg:"Expected response Content-Type \"application/protobuf\" but found \"application/protobuf; charset=utf-8\"" 
    meta:{}
  >
>
```


This also conforms with the Twirp v7 spec:


> Content-Type The value should be either "application/protobuf" or "application/json" to indicate the encoding of the response message. It must match the "Content-Type" header in the request.
> https://github.com/twitchtv/twirp/blob/ded153e52e9e279471e020135e42e5e3f1000276/docs/spec_v7.md#responses

This PR sets the content-type's charset to `nil` to explicitly remove the default utf8 charset

https://hexdocs.pm/plug/Plug.Conn.html#put_resp_content_type/3