### PR TITLE
Use Jason.encode! when sending errors

### DIFF
--- a/lib/twirp/plug.ex
+++ b/lib/twirp/plug.ex
@@ -279,11 +279,10 @@ defmodule Twirp.Plug do
   end
 
   defp send_error(conn, error) do
-    content_type = Encoder.type(:json)
-    body = Encoder.encode(error, nil, content_type)
+    body = Jason.encode!(error)
 
     conn
-    |> put_resp_content_type(content_type)
+    |> put_resp_content_type("application/json")
     |> send_resp(Error.code_to_status(error.code), body)
     |> halt()
   end

--- a/lib/twirp/plug.ex
+++ b/lib/twirp/plug.ex
@@ -105,7 +105,7 @@ defmodule Twirp.Plug do
         Telemetry.stop(:call, start, metadata)
 
         conn
-        |> put_resp_content_type(env.content_type)
+        |> put_resp_content_type(env.content_type, nil)
         |> send_resp(200, resp)
         |> halt()
       else
@@ -283,7 +283,7 @@ defmodule Twirp.Plug do
     body = Encoder.encode(error, nil, content_type)
 
     conn
-    |> put_resp_content_type(content_type)
+    |> put_resp_content_type(content_type, nil)
     |> send_resp(Error.code_to_status(error.code), body)
     |> halt()
   end

--- a/test/twirp/plug_test.exs
+++ b/test/twirp/plug_test.exs
@@ -112,6 +112,16 @@ defmodule Twirp.PlugTest do
     assert conn == req
   end
 
+  test "does not include the __exception__ field" do
+    req = conn(:get, "/twirp/plug.test.Haberdasher/MakeHat")
+    conn = call(req)
+
+    assert conn.status == 404
+    assert content_type(conn) == "application/json"
+    body = Jason.decode!(conn.resp_body)
+    refute Map.has_key?(body, "__exception__")
+  end
+
   test "not a POST" do
     req = conn(:get, "/twirp/plug.test.Haberdasher/MakeHat")
     conn = call(req)
@@ -299,7 +309,7 @@ defmodule Twirp.PlugTest do
     resp = Jason.decode!(conn.resp_body)
     assert resp["code"] == "internal"
     assert resp["msg"] == "Blow this ish up"
-    assert resp["meta"] == %{}
+    refute Map.has_key?(resp, "meta")
   end
 
   describe "before" do

--- a/test/twirp/plug_test.exs
+++ b/test/twirp/plug_test.exs
@@ -73,10 +73,9 @@ defmodule Twirp.PlugTest do
   end
 
   def content_type(conn) do
-    conn.resp_headers
-    |> Enum.find_value(fn {h, v} -> if h == "content-type", do: v, else: false end)
-    |> String.split(";") # drop the charset if there is one
-    |> Enum.at(0)
+   Enum.find_value(conn.resp_headers, fn {h, v} ->
+      if h == "content-type", do: v, else: false
+    end)
   end
 
   def call(req, opts \\ @opts) do


### PR DESCRIPTION
At the moment `Twirp.Plug.send_error/2` uses `Twirp.Encoder.encode/3` for encoding the error.

This leads to a problem where the `defimpl Jason.Encoder` for the `Twirp.Error` struct is not being used, and thus the `:__exception__` field is being sent with every error response.

The [twirp specification v7](https://twitchtv.github.io/twirp/docs/spec_v7.html#errors) describes how error responses must be encoded:

```json
 {
  "code": "permission_denied",
  "msg": "Thou shall not pass",
  "meta": {
    "target": "Balrog",
    "power": "999"
  }
}
```

`code` and `msg` are required while `meta` is optional.

The twirp-elixir implementation will send the following:

```json
{
  "__exception__": true,
  "code": "permission_denied",
  "msg": "Thou shall not pass",
  "meta": {
    "target": "Balrog",
    "power": "999"
  }
}
```

The [twirp go implementation](https://github.com/twitchtv/twirp) is very strict about the errors

```golang
var tj twerrJSON
dec := json.NewDecoder(bytes.NewReader(respBodyBytes))
dec.DisallowUnknownFields()
if err := dec.Decode(&tj); err != nil || tj.Code == "" {
	// Invalid JSON response; it must be an error from an intermediary.
	msg := fmt.Sprintf("Error from intermediary with HTTP status code %d %q", statusCode, statusText)
	return twirpErrorFromIntermediary(statusCode, msg, string(respBodyBytes))
}
```

This leads the Go implementation to handle the error as if it originated from an intermediary (e.g. a reverse proxy) and translating the HTTP status code 404 as a bad_route instead of the original error.


This PR makes use of `Jason.encode!/1` in the `Twirp.Plug.send_error/2` to fix this issue, as it will use the protocol implementation found in `Twirp.Error`.