### PR TITLE
Correct typespec of error's meta

### DIFF
--- a/lib/twirp/error.ex
+++ b/lib/twirp/error.ex
@@ -38,7 +38,7 @@ defmodule Twirp.Error do
   @type t :: %__MODULE__{
     code: atom(),
     msg: binary(),
-    meta: %{atom() => binary()}
+    meta: %{optional(binary()) => binary()} | nil
   }
 
   for code <- @error_codes do


### PR DESCRIPTION
according to [Twirp's spec](https://twitchtv.github.io/twirp/docs/errors.html)  and https://github.com/keathley/twirp-elixir/pull/138, `meta` field in error struct is optional and should be use string key